### PR TITLE
Created Update_members Endpoint

### DIFF
--- a/server/src/controllers/member.ts
+++ b/server/src/controllers/member.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
-import { getAllMembersService } from "../services/memberServices";
+import { getAllMembersService, updateMemberService } from "../services/memberServices";
+import { MemberUpdate } from "../models/member";
 
 /**
  * Get all members
@@ -11,5 +12,30 @@ export const getAllMembers = async (req: Request, res: Response): Promise<void> 
   } catch (error) {
     console.error("Error fetching members:", error);
     res.status(500).json({ error: "Failed to fetch members" });
+  }
+};
+
+/**
+ * Update a member by their unique ID
+ */
+export const updateMember = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const updates: MemberUpdate = req.body;
+
+    if (!id) {
+      res.status(400).json({ error: "Member ID is required" });
+      return;
+    }
+
+    const updatedMember = await updateMemberService(id, updates);
+    res.status(200).json(updatedMember);
+  } catch (error) {
+    console.error("Error updating member:", error);
+    if (error instanceof Error && error.message === "Member not found") {
+      res.status(404).json({ error: "Member not found" });
+    } else {
+      res.status(500).json({ error: "Failed to update member" });
+    }
   }
 };

--- a/server/src/routes/member.ts
+++ b/server/src/routes/member.ts
@@ -1,10 +1,14 @@
 import express from "express";
-import { getAllMembers } from "../controllers/member";
+import { getAllMembers, updateMember } from "../controllers/member";
 
 const router = express.Router();
 
 // GET /api/members - Get all members
 // Documentation is handled in swagger/paths.ts
 router.get("/", getAllMembers);
+
+// POST /api/members/:id - Update a member by ID
+// Documentation is handled in swagger/paths.ts
+router.post("/:id", updateMember);
 
 export default router;

--- a/server/src/services/memberServices.ts
+++ b/server/src/services/memberServices.ts
@@ -4,6 +4,7 @@ import {
   MemberRecord,
   MemberRole,
   SupabaseMemberRow,
+  MemberFields,
 } from "../models/member";
 
 export interface MemberListFilters {
@@ -27,12 +28,12 @@ const escapeLikePattern = (value: string): string =>
 const mapRowToMember = (row: SupabaseMemberRow): MemberRecord => ({
   id: row.id,
   name: row.name,
-  profilePicture: row.profile_picture ?? row.profilePicture ?? undefined,
+  profilePicture: row.profile_picture ?? undefined,
   role: row.role,
   team: row.team,
-  dateJoined: row.date_joined ?? row.dateJoined ?? "",
+  dateJoined: row.date_joined ?? "",
   email: row.email,
-  linkedIn: row.linkedin ?? row.linked_in ?? undefined,
+  linkedIn: row.linkedIn ?? undefined,
   bio: row.bio ?? undefined,
   created_at: row.created_at,
 });
@@ -100,4 +101,60 @@ export const getAllMembersService = async (): Promise<MemberRecord[]> => {
   }
 
   return (data ?? []).map(mapRowToMember);
+};
+
+/**
+ * Update a member by their unique ID
+ * @param id - The unique identifier of the member to update
+ * @param updates - The fields to update
+ * @returns Promise with the updated member record
+ */
+export const updateMemberService = async (
+  id: string,
+  updates: Partial<MemberFields>
+): Promise<MemberRecord> => {
+  // Convert camelCase to snake_case for Supabase
+  const supabaseUpdates: any = {};
+  
+  if (updates.profilePicture !== undefined) {
+    supabaseUpdates.profile_picture = updates.profilePicture;
+  }
+  if (updates.dateJoined !== undefined) {
+    supabaseUpdates.date_joined = updates.dateJoined;
+  }
+  if (updates.linkedIn !== undefined) {
+    supabaseUpdates.linkedIn = updates.linkedIn;
+  }
+  if (updates.name !== undefined) {
+    supabaseUpdates.name = updates.name;
+  }
+  if (updates.role !== undefined) {
+    supabaseUpdates.role = updates.role;
+  }
+  if (updates.team !== undefined) {
+    supabaseUpdates.team = updates.team;
+  }
+  if (updates.email !== undefined) {
+    supabaseUpdates.email = updates.email;
+  }
+  if (updates.bio !== undefined) {
+    supabaseUpdates.bio = updates.bio;
+  }
+
+  const { data, error } = await supabase
+    .from(MEMBERS_TABLE)
+    .update(supabaseUpdates)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data) {
+    throw new Error("Member not found");
+  }
+
+  return mapRowToMember(data);
 };

--- a/server/src/swagger/paths.ts
+++ b/server/src/swagger/paths.ts
@@ -27,5 +27,75 @@ export const memberPaths = {
         }
       }
     }
+  },
+  '/api/members/{id}': {
+    post: {
+      summary: 'Update a member',
+      description: 'Update a member by their unique ID',
+      tags: ['Members'],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the member to update',
+          schema: {
+            type: 'string'
+          }
+        }
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/MemberUpdate'
+            }
+          }
+        }
+      },
+      responses: {
+        '200': {
+          description: 'Member successfully updated',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Member'
+              }
+            }
+          }
+        },
+        '400': {
+          description: 'Bad request - Member ID is required',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Error'
+              }
+            }
+          }
+        },
+        '404': {
+          description: 'Member not found',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Error'
+              }
+            }
+          }
+        },
+        '500': {
+          description: 'Internal server error',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Error'
+              }
+            }
+          }
+        }
+      }
+    }
   }
 };

--- a/server/src/swagger/schemas.ts
+++ b/server/src/swagger/schemas.ts
@@ -60,6 +60,51 @@ export const memberSchemas = {
     }
   },
   
+  MemberUpdate: {
+    type: 'object',
+    properties: {
+      name: { 
+        type: 'string',
+        description: 'Full name of the member'
+      },
+      profilePicture: { 
+        type: 'string',
+        nullable: true,
+        description: 'URL to profile picture'
+      },
+      role: { 
+        type: 'string',
+        enum: ['COD', 'TL/PM', 'Engineering Chair', 'Design Lead', 'NME Instructor', 'Member', 'Newbie'],
+        description: 'Role of the member in the organization'
+      },
+      team: { 
+        type: 'string',
+        description: 'Team the member belongs to'
+      },
+      dateJoined: { 
+        type: 'string',
+        format: 'date',
+        description: 'Date when the member joined'
+      },
+      email: { 
+        type: 'string',
+        format: 'email',
+        description: 'Email address of the member'
+      },
+      linkedIn: { 
+        type: 'string',
+        nullable: true,
+        description: 'LinkedIn profile URL'
+      },
+      bio: { 
+        type: 'string',
+        nullable: true,
+        description: 'Short biography of the member'
+      }
+    },
+    description: 'Fields that can be updated for a member. All fields are optional.'
+  },
+  
   Error: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Overview

Added POST endpoint for updating members by their unique ID. Allows partial updates of member information.

## Testing

Manual Testing:
Started server with npm run dev
Tested via Swagger UI at http://localhost:8000/docs/#/
Verified endpoint: POST /api/members/{id}
Tested with existing member ID and partial update data
Confirmed proper error handling (400, 404, 500)

Example Test:
{
  "name": "Updated Name",
  "role": "Member"
}

## Notes

All fields optional for partial updates
Complete Swagger documentation included

## Screenshots

<img width="738" height="179" alt="IMG_0394" src="https://github.com/user-attachments/assets/3487ba4a-6a30-46c4-8e7a-ca92b7927c79" />
<img width="1135" height="603" alt="IMG_2575" src="https://github.com/user-attachments/assets/bf71320a-79f1-46c6-b67c-5a410ca871f2" />
<img width="1143" height="667" alt="IMG_0009" src="https://github.com/user-attachments/assets/5d0a7845-09af-40a6-a188-fb846f1943b1" />

